### PR TITLE
Nan check fix

### DIFF
--- a/development/develop_script.py
+++ b/development/develop_script.py
@@ -27,33 +27,31 @@ static_data = os.path.join(
     str(lib_folder), 'static_data', 'vlinder_metadata.csv')
 
 
+#Testdata
+testdatafile = '/home/thoverga/Documents/VLINDER_github/vlinder_toolkit/tests/test_data/testdata_breaking.csv'
+
+template = '/home/thoverga/Documents/VLINDER_github/vlinder_toolkit/tests/test_data/template_breaking.csv'
+
+
 # #% Setup dataset
 settings = vlinder_toolkit.Settings()
 settings.update_settings(input_data_file=testdatafile,
-                         input_metadata_file=static_data,
+                         # input_metadata_file=static_data,
                          output_folder='/home/thoverga/Documents/VLINDER_github/vlinder_toolkit'
                          )
-
+settings.add_csv_template(template)
 
 dataset = vlinder_toolkit.Dataset()
-dataset.import_data_from_file(coarsen_timeres=True)
+
+
+df = dataset.import_data_from_file(coarsen_timeres=False)
 
 
 dataset.apply_quality_control()
 
-dataset.write_to_csv()
+dataset.get_qc_stats()
 
 
-
-
-
-
-# test = dataset.get_qc_stats()
-
-
-
-#%%
-
-
-
+    
+    
 #%% 

--- a/development/develop_script.py
+++ b/development/develop_script.py
@@ -27,31 +27,26 @@ static_data = os.path.join(
     str(lib_folder), 'static_data', 'vlinder_metadata.csv')
 
 
-#Testdata
-testdatafile = '/home/thoverga/Documents/VLINDER_github/vlinder_toolkit/tests/test_data/testdata_breaking.csv'
-
-template = '/home/thoverga/Documents/VLINDER_github/vlinder_toolkit/tests/test_data/template_breaking.csv'
-
-
 # #% Setup dataset
 settings = vlinder_toolkit.Settings()
 settings.update_settings(input_data_file=testdatafile,
                          # input_metadata_file=static_data,
                          output_folder='/home/thoverga/Documents/VLINDER_github/vlinder_toolkit'
                          )
-settings.add_csv_template(template)
 
 dataset = vlinder_toolkit.Dataset()
 
 
-df = dataset.import_data_from_file(coarsen_timeres=False)
+df = dataset.import_data_from_file(coarsen_timeres=True)
 
 
 dataset.apply_quality_control()
 
+#add obstype to get qc stats
+
 dataset.get_qc_stats()
 
 
-    
+test = dataset.combine_all_to_obsspace()
     
 #%% 

--- a/examples/qualitycontrol_example.py
+++ b/examples/qualitycontrol_example.py
@@ -141,9 +141,10 @@ print(sept_2022_all_vlinders.df.columns)
 
 # After applying the Quality control each observations (that is checked) has a set of qc-labels. 
 # To create One column with the final label (based on the labels for each check), you can call the 
-# add_final_qc_labels, which will add a final-qc-label column in the dataset.df:
+# combine_all_to_obsspace, which will combine observations, outliers gaps and missing timestamps,
+ # and add a final-qc-label column per obstype:
 
-outliers_sept_2022_all_vlinders = sept_2022_all_vlinders.get_final_qc_labels()
+outliers_sept_2022_all_vlinders = sept_2022_all_vlinders.combine_all_to_obsspace()
 
 print(outliers_sept_2022_all_vlinders['temp_final_label'].head())
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -710,14 +710,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0dev)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.80.0"
+version = "2.81.0"
 description = "Google API Client Library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-python-client-2.80.0.tar.gz", hash = "sha256:51dd62d467da7ad3df63c3f0e6fca84266ce50c2218691204b2e8cd651a0719a"},
-    {file = "google_api_python_client-2.80.0-py2.py3-none-any.whl", hash = "sha256:b9cd2550c2cdfeb78c3150d8c52208841082dabe597063a116476937170907ab"},
+    {file = "google-api-python-client-2.81.0.tar.gz", hash = "sha256:8faab0b9b19d3797b455d33320c643253b6761fd0d3f3adb54792ab155d0795a"},
+    {file = "google_api_python_client-2.81.0-py2.py3-none-any.whl", hash = "sha256:ad6700ae3a76ead8956d7f30935978cea308530e342ad8c1e26a4e40fc05c054"},
 ]
 
 [package.dependencies]
@@ -2394,14 +2394,14 @@ files = [
 
 [[package]]
 name = "trove-classifiers"
-version = "2023.2.20"
+version = "2023.3.9"
 description = "Canonical source for classifiers on PyPI (pypi.org)."
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "trove-classifiers-2023.2.20.tar.gz", hash = "sha256:860b0c0d8c9e0d32629ca5ef137ea1e637580b634b74ba40e1539fd34464c0f5"},
-    {file = "trove_classifiers-2023.2.20-py3-none-any.whl", hash = "sha256:de61417c958b06fd4923b2e26d4e70dd7ffc691d5435bcd7ed78d061278885f1"},
+    {file = "trove-classifiers-2023.3.9.tar.gz", hash = "sha256:ee42f2f8c1d4bcfe35f746e472f07633570d485fab45407effc0379270a3bb03"},
+    {file = "trove_classifiers-2023.3.9-py3-none-any.whl", hash = "sha256:06fd10c95d285e7ddebd59e6a4ba299f03d7417d38d369248a4a40c9754a68fa"},
 ]
 
 [[package]]
@@ -2418,14 +2418,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.14"
+version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
-    {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
 ]
 
 [package.extras]
@@ -2456,14 +2456,14 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 
 [[package]]
 name = "virtualenv"
-version = "20.20.0"
+version = "20.21.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.20.0-py3-none-any.whl", hash = "sha256:3c22fa5a7c7aa106ced59934d2c20a2ecb7f49b4130b8bf444178a16b880fa45"},
-    {file = "virtualenv-20.20.0.tar.gz", hash = "sha256:a8a4b8ca1e28f864b7514a253f98c1d62b64e31e77325ba279248c65fb4fcef4"},
+    {file = "virtualenv-20.21.0-py3-none-any.whl", hash = "sha256:31712f8f2a17bd06234fa97fdf19609e789dd4e3e4bf108c3da71d710651adbc"},
+    {file = "virtualenv-20.21.0.tar.gz", hash = "sha256:f50e3e60f990a0757c9b68333c9fdaa72d7188caa417f96af9e52407831a3b68"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -582,19 +582,19 @@ requests = "*"
 
 [[package]]
 name = "filelock"
-version = "3.9.0"
+version = "3.9.1"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
-    {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
+    {file = "filelock-3.9.1-py3-none-any.whl", hash = "sha256:4427cdda14a1c68e264845142842d6de2d0fa2c15ba31571a3d9c9a1ec9d191c"},
+    {file = "filelock-3.9.1.tar.gz", hash = "sha256:e393782f76abea324dee598d2ea145b857a20df0e0ee4f80fcf35e72a341d2c7"},
 ]
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.1)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "fiona"

--- a/tests/push_test/breaking_test.py
+++ b/tests/push_test/breaking_test.py
@@ -119,7 +119,17 @@ assert all([True for label in all_manual_labels if label in manual_to_tlkit_labe
 # iterate over all labels and validate if the indices are equal between manual and toolkit
 # =============================================================================
 
+to_check = ['ok',
+            'in step outlier group',
+            'repetitions outlier',
+            # 'duplicated timestamp outlier',
+            'gross value outlier',
+            'in window variation outlier group',
+            'persistance outlier']
 for man_label, tlk_label in manual_to_tlkit_label_map.items():
+    if not man_label in to_check:
+        continue
+    
     print(f' Testing equality of the {tlk_label} with the manual labeling ({man_label}).')
     
     man_idx = man_df[man_df['flags'] == man_label].index.sort_values()
@@ -137,6 +147,30 @@ for man_label, tlk_label in manual_to_tlkit_label_map.items():
         print('OK!')
 
 
+# =============================================================================
+# test duplicates
+# =============================================================================
+# tested seperatly because duplicates are in tlk stored as one record, to avoid 
+# duplicate index errors. So we have to do the same for the manual labeling
+man_label = 'duplicated timestamp outlier'
+tlk_label = manual_to_tlkit_label_map[man_label]
+
+print(f' Testing equality of the {tlk_label} with the manual labeling ({man_label}).')
+
+man_df_no_duplic = man_df[~man_df.index.duplicated(keep='first')]
+
+man_idx = man_df_no_duplic[man_df_no_duplic['flags'] == man_label].index.sort_values()
+tlk_idx = tlk_df[tlk_df['temp_final_label'] == tlk_label].index.sort_values()
+
+if not tlk_idx.equals(man_idx):
+    print(f'ERROR: wrong labels for {tlk_label}')
+    
+    print(f'differences tlkit --> manual: { tlk_idx.difference(man_idx)}')
+    print(f'differences manual --> tlkit: {man_idx.difference(tlk_idx)}')
+    sys.exit(1)
+
+else:
+    print('OK!')
 # =============================================================================
 # test missing Gaps
 # =============================================================================

--- a/tests/push_test/qc_test.py
+++ b/tests/push_test/qc_test.py
@@ -33,23 +33,22 @@ dataset.import_data_from_file(coarsen_timeres=True)
 
 #%% Apply Qc on dataset level
 
-dataset.apply_quality_control(obstype='temp',
-                                            gross_value=True, #apply this check 
-                                            persistance=True, #apply this check
-                                            )
+dataset.apply_quality_control(obstype='temp')
 
 
 outliersdf = dataset.get_final_qc_labels()
-
+dataset.get_qc_stats(make_plot = False)
 
 
 #%% Apply Qc on obstype not specified in settings
 
 
 
-dataset.apply_quality_control(obstype='humidity',
-                                            gross_value=True, #apply this check 
-                                            persistance=True, #apply this check
-                                            )
+dataset.apply_quality_control(obstype='humidity')
 
+#%% Apply QC on station level
 
+sta = dataset.get_station('vlinder05')
+
+sta.apply_quality_control()
+sta.get_qc_stats(make_plot=True)

--- a/tests/push_test/qc_test.py
+++ b/tests/push_test/qc_test.py
@@ -36,7 +36,7 @@ dataset.import_data_from_file(coarsen_timeres=True)
 dataset.apply_quality_control(obstype='temp')
 
 
-outliersdf = dataset.get_final_qc_labels()
+outliersdf = dataset.combine_all_to_obsspace()
 dataset.get_qc_stats(make_plot = False)
 
 

--- a/vlinder_toolkit/dataset.py
+++ b/vlinder_toolkit/dataset.py
@@ -606,6 +606,15 @@ class Dataset:
         ignore_obstypes = Settings.observation_types.copy()
         ignore_obstypes.remove(obstype)
         comb_df = comb_df.drop(columns=ignore_obstypes)
+        # drop label columns not applicable on obstype
+        relevant_columns = [col for col in comb_df.columns if col.startswith(obstype)]
+        
+        # add all columns of checks applied on records (i.g. without obs prefix like duplicate timestamp)
+        record_check = {key: item['label_columnname'] for key, item in Settings.qc_checks_info.items() if item['apply_on'] == 'record'}
+        relevant_columns.extend(list(record_check.values()))
+        # filter relevant columns
+        comb_df = comb_df[relevant_columns]
+        
 
         # compute freq statistics
         final_freq, outl_freq, specific_freq = get_freq_statistics(

--- a/vlinder_toolkit/dataset.py
+++ b/vlinder_toolkit/dataset.py
@@ -655,16 +655,7 @@ class Dataset:
         self.outliersdf[new_performed_checks_columns] = self.outliersdf[
             new_performed_checks_columns].fillna(value='not checked')
 
-    def get_final_qc_labels(self):
-
-        # add final quality labels
-
-        outldf = add_final_label_to_outliersdf(
-                        outliersdf=self.outliersdf,
-                        data_res_series=self.metadf['dataset_resolution'])
-
-        return outldf
-
+   
     # =============================================================================
     #     importing data
     # =============================================================================

--- a/vlinder_toolkit/dataset.py
+++ b/vlinder_toolkit/dataset.py
@@ -612,6 +612,7 @@ class Dataset:
         # add all columns of checks applied on records (i.g. without obs prefix like duplicate timestamp)
         record_check = {key: item['label_columnname'] for key, item in Settings.qc_checks_info.items() if item['apply_on'] == 'record'}
         relevant_columns.extend(list(record_check.values()))
+        relevant_columns = [col for col in relevant_columns if col in comb_df.columns]
         # filter relevant columns
         comb_df = comb_df[relevant_columns]
         

--- a/vlinder_toolkit/df_helpers.py
+++ b/vlinder_toolkit/df_helpers.py
@@ -15,6 +15,22 @@ import geopandas as gpd
 from vlinder_toolkit.settings import Settings
 
 
+
+def init_outlier_multiindexdf():
+    my_index = pd.MultiIndex(levels=[['name'],['datetime']],
+                             codes=[[],[]],
+                             names=[u'name', u'datetime'])
+
+   
+    df = pd.DataFrame(index=my_index)
+    return df
+
+def init_outlier_multiindex():
+     return pd.MultiIndex(levels=[['name'],['datetime']],
+                             codes=[[],[]],
+                             names=[u'name', u'datetime'])
+
+
 def add_final_label_to_outliersdf(outliersdf, data_res_series):
     """
     V3
@@ -87,10 +103,10 @@ def add_final_label_to_outliersdf(outliersdf, data_res_series):
 
 
 def remove_outliers_from_obs(obsdf, outliersdf):
+    #TODO this function can only be used with care!!! 
+    # because all timestamps will be removed that have an oulier in one specific obstype !!!!
     return obsdf.loc[~obsdf.index.isin(outliersdf.index)]
 
-    
-  
 
 
 

--- a/vlinder_toolkit/plotting_functions.py
+++ b/vlinder_toolkit/plotting_functions.py
@@ -272,7 +272,15 @@ def _make_pie_from_freqs(freq_dict, colormapper, radius, ax,
 
     # make color mapper
     stats['color'] = stats.index.map(colormapper)
- 
+    if (stats['freq'] == 0.0).all():
+        print('No occurences in sample.')
+        #add a 100% no occurences to it, so it can be plotted
+        no_oc_df = pd.DataFrame(index=['No occurences'],
+                     data={'freq': [100.0],
+                           'color':[Settings.plot_settings['color_mapper']['ok']]})
+        stats = pd.concat([stats, no_oc_df])
+        
+        
     # Make pie and legend 
     patches, text = ax.pie(stats['freq'], colors=stats['color'], radius=radius)
     ax.legend(handles=patches, labels = [f'{l}, {s:0.1f}%' for l, s in zip(stats.index.to_list(),

--- a/vlinder_toolkit/plotting_functions.py
+++ b/vlinder_toolkit/plotting_functions.py
@@ -356,7 +356,9 @@ def qc_stats_pie(final_stats, outlier_stats, specific_stats):
     spec_col_mapper = {
         'ok': color_defenitions['ok'],
         'not checked': color_defenitions['not checked'],
-        'outlier': color_defenitions['outlier']
+        'outlier': color_defenitions['outlier'],
+        'gap': color_defenitions['gap'],
+        'missing timestamp': color_defenitions['missing_timestamp']
         }
     
     i=0

--- a/vlinder_toolkit/qc_checks.py
+++ b/vlinder_toolkit/qc_checks.py
@@ -27,77 +27,6 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 # Helper functions
 # =============================================================================
-# def init_outlier_multiindexdf():
-#     my_index = pd.MultiIndex(levels=[['name'],['datetime']],
-#                              codes=[[],[]],
-#                              names=[u'name', u'datetime'])
-
-   
-#     df = pd.DataFrame(index=my_index)
-#     return df
-
-# def make_outlier_df_for_check(station_dt_list, values_in_dict, flagcolumnname, flag, stationname=None, datetimelist=None):
-#     """
-#     V3
-#     Helper function to create an outlier dataframe for the given station(s) and datetimes. This will be returned by 
-#     a quality control check and later added to the dastes.outlierdf. 
-    
-#     Multiple commum inputstructures can be handles
-    
-#     A multiindex dataframe with the relevant observationtypes i.e. the values_in_dict and a specific quality flag column (i.g. the labels) is returned.
-#     Parameters
-#     ----------
-#     station_dt_list : MultiIndex or list of tuples: (name, datetime)
-#         The stations with corresponding datetimes that are labeled as outliers.
-#     values_in_dict : Dictionary
-#         A Dictionary {columnname: pd.Series()} with the values on which this check is applied.
-#     flagcolumnname : String
-#         Name of the labels column
-#     flag : String
-#         The label for all the outliers.
-#     stationname : String, optional
-#         It is possible to give the name of one station. The default is None.
-#     datetimelist : DatetimeIndex or List, optional
-#         The outlier timestamps for the stationname. The default is None.
-#     Returns
-#     -------
-#     check_outliers : pd.Dataframe
-#         A multiindex (name -- datetime) datatframe with one column (columname) and all
-#         values are the flag.
-#     """
-
-        
-#     columnorder =list(values_in_dict.keys())
-#     columnorder.append(flagcolumnname)
-        
-    
-#     if isinstance(station_dt_list, pd.MultiIndex):
-#         check_outliers = pd.DataFrame(data=flag, index=station_dt_list, columns=[flagcolumnname])
-#         for obstype, obsvalues in values_in_dict.items():    
-#             check_outliers[obstype] = obsvalues
-#         check_outliers = check_outliers[columnorder]
-#         return check_outliers
-#     elif isinstance(station_dt_list, list): #list of tuples: (name, datetime)
-#         multi_idx = pd.MultiIndex.from_tuples(station_dt_list, names=['name', 'datetime'])
-#         check_outliers = pd.DataFrame(data=flag, index=multi_idx, columns=[flagcolumnname])
-#         for obstype, obsvalues in values_in_dict.items():    
-#             check_outliers[obstype] = obsvalues
-#         check_outliers = check_outliers[columnorder]
-#         return check_outliers
-#     elif not isinstance(stationname, type(None)):
-#         if isinstance(datetimelist, pd.DatetimeIndex):
-#             datetimelist = datetimelist.to_list()
-#         if isinstance(datetimelist, list):
-#             indexarrays = list(zip([stationname]*len(datetimelist), datetimelist))
-#             multi_idx = pd.MultiIndex.from_tuples(indexarrays, names=['name', 'datetime'])
-#             check_outliers = pd.DataFrame(data=flag, index=multi_idx, columns=[flagcolumnname])
-#             for obstype, obsvalues in values_in_dict.items():    
-#                 check_outliers[obstype] = obsvalues
-#             check_outliers = check_outliers[columnorder]
-#             return check_outliers
-#         else:
-#             sys.exit(f'Type of datetimelist: {type(datetimelist)} is not implemented.')
-
 
 
 def make_outlier_df_for_check(station_dt_list, obsdf, obstype,
@@ -171,22 +100,6 @@ def make_outlier_df_for_check(station_dt_list, obsdf, obstype,
 # =============================================================================
 
 
-# def invalid_input_check(df, obstype):
-    
-#     checkname = 'invalid_input'
-    
-#     nan_df = df[df[obstype].isnull()]
-#     nan_indices = nan_df.index
-
-#     outlierdf = make_outlier_df_for_check(station_dt_list = nan_indices,
-#                                           values_in_dict = nan_df.to_dict(orient='series'),
-#                                           flagcolumnname=obstype+'_'+checks_info[checkname]['label_columnname'],
-#                                           flag=checks_info[checkname]['outlier_flag'])
-    
-#     df = df.drop(nan_indices)
-    
-#     return df, outlierdf
-
 def invalid_input_check(df):
         
     checkname = 'invalid_input'
@@ -225,6 +138,7 @@ def invalid_input_check(df):
     
     return df, outl_df
   
+    
 def duplicate_timestamp_check(df):
     """
     V3
@@ -657,45 +571,4 @@ def get_outliers_in_daterange(input_data, date, name, time_window, station_freq)
     return intersection
 
 
-
-
-# def qc_info(qc_dataframe):
-    
-#     number_gross_error_outliers = qc_dataframe.persistance.str.contains('gross value outlier').sum()
-#     number_persistance_outliers = qc_dataframe.persistance.str.contains('persistance outlier').sum()
-#     number_step_outliers = qc_dataframe.persistance.str.contains('step outlier').sum()
-#     number_int_consistency_outliers = qc_dataframe.persistance.str.contains('internal consistency outlier').sum()
-    
-#     fraction_gross_outliers = number_gross_error_outliers/(number_gross_error_outliers+number_persistance_outliers+number_step_outliers+number_int_consistency_outliers)
-#     fraction_persistance_outliers = number_persistance_outliers/(number_gross_error_outliers+number_persistance_outliers+number_step_outliers+number_int_consistency_outliers)
-#     fraction_step_outliers = number_step_outliers/(number_gross_error_outliers+number_persistance_outliers+number_step_outliers+number_int_consistency_outliers)
-#     fraction_int_consistency_outliers = number_int_consistency_outliers/(number_gross_error_outliers+number_persistance_outliers+number_step_outliers+number_int_consistency_outliers)
-    
-#     percentage_of_data_gross_outlier = number_gross_error_outliers/len(qc_dataframe)
-#     percentage_of_data_persistance_outlier = number_persistance_outliers/len(qc_dataframe)
-#     percentage_of_data_step_outlier = number_step_outliers/len(qc_dataframe)
-#     percentage_of_data_consistency_outlier = number_int_consistency_outliers/len(qc_dataframe)
-    
-#     print("Number of gross error outliers: ", number_gross_error_outliers)
-#     print("Number of persistance outliers: ", number_persistance_outliers)
-#     print("Number of step outliers: ", number_step_outliers)
-#     print("Number of internal consistency outliers: ", number_int_consistency_outliers)
-    
-#     print("Fraction of gross error outliers: ", fraction_gross_outliers)
-#     print("Fraction of persistance outliers: ", fraction_persistance_outliers)
-#     print("Fraction of step outliers: ", fraction_step_outliers)
-#     print("Fraction of internal consistency outliers: ", fraction_int_consistency_outliers)
-    
-#     print("Percentage of data gross outlier: ", percentage_of_data_gross_outlier)
-#     print("Percentage of data persistance outlier: ", percentage_of_data_persistance_outlier)
-#     print("Percentage of data step outlier: ", percentage_of_data_step_outlier)
-#     print("Percentage of data internal consistency outlier: ", percentage_of_data_consistency_outlier)
-    
-#     print("Gross error outliers at: ", qc_dataframe[qc_dataframe['gross_value'] == 'gross value outlier'].index)
-#     print("Persistance outliers at: ", qc_dataframe[qc_dataframe['persistance'] == 'persistance outlier'].index)
-#     print("Step outliers at: ", qc_dataframe[qc_dataframe['step'] == 'step outlier'].index)
-#     print("Internal consistency outliers at: ", qc_dataframe[qc_dataframe['internal_consistency'] == 'internal consistency outlier'].index)
-#     print("Humidity 0 at: ", qc_dataframe[qc_dataframe['internal_consistency'] == 'humidity 0'].index)
-    
-    
 


### PR DESCRIPTION
In order to proper handle ouliers for different obstypes, it is important not to drop the record once an outlier is found in an obstype at that record. Therefore the outliers should be present in dataset.df but the value is converted to nan. 

This implicates multiple functions. This branch handles that.