### PR TITLE
Fix logging of windows that are too small for window variation check

### DIFF
--- a/examples/qualitycontrol_example.py
+++ b/examples/qualitycontrol_example.py
@@ -83,13 +83,12 @@ sept_2022_all_vlinders.import_data_from_file(settings, coarsen_timeres=True) #Re
             
 #All settings, labels, replacement values are defind in the default settings in /settings_files/qc_settings.py
 #To inspect (and change) these quality control settings, you can extract them out of the Settings:
-
-qc_settings = settings.qc_check_settings #Settings are stored in nested dictionary
+qc_settings = settings.qc_check_settings
 print(qc_settings)
 
 #Changing a setting example:
-settings.qc_check_settings['persistance']['temp']['max_valid_repetitions'] = 6
-
+qc_settings['repetitions']['temp']['max_valid_repetitions'] = 6
+print(qc_settings)
 
         
 # Quality control checks are always applied on the full dataset Using the apply_quality_control method on the dataset.
@@ -100,7 +99,6 @@ sept_2022_all_vlinders.apply_quality_control(obstype='temp', #which observations
                                              step=True, #apply the step chec?
                                              window_variation=True # apply internal consistency check?
                                              )
-
 
 # ----- INTERMEZZO ------
 # quality control methods can also be applied on station level. Be aware that the QC labels are an attribute of the station

--- a/tests/push_test/breaking_test.py
+++ b/tests/push_test/breaking_test.py
@@ -11,6 +11,7 @@ Created on Tue Nov 29 12:19:03 2022
 """
 
 import sys, os
+import pandas as pd
 
 from pathlib import Path
 
@@ -42,7 +43,7 @@ max_value = 50.0 # Maximal allowed value
 max_increase_per_second = 8.0/3600.0   # Maximal allowed increase per second (for window variation check)
 max_decrease_per_second = 10.0/3600.0   # Maximal allowed decrease per second (for window variation check)
 time_window_to_check = '1h'   # Use this format as example: "1h20min50s"
-min_window_members = 3 # Minimal number of records in window to perform check
+min_window_members = 5 # Minimal number of records in window to perform check
 
 max_increase_per_second_step = 8.0/3600.0   # Maximal allowed increase per second (for step check)
 max_decrease_per_second_step = -10.0/3600.0   # Maximal allowed increase per second (for step check)

--- a/tests/push_test/breaking_test.py
+++ b/tests/push_test/breaking_test.py
@@ -11,7 +11,6 @@ Created on Tue Nov 29 12:19:03 2022
 """
 
 import sys, os
-import pandas as pd
 
 from pathlib import Path
 
@@ -33,7 +32,7 @@ minimal_gapsize = 10    #gaps defined as n times the highest frequency on IO.
 dupl_dropping = False #method used to drop duplicated timestamps
 
 persistance_time_window_to_check = '1h'   # Use this format as example: "1h20min50s"
-min_num_obs = 5   #Minimum number of records in window to perform persistance check
+min_num_obs = 3   #Minimum number of records in window to perform persistance check
 
 max_valid_repetitions = 5 # Maximal number of repetitions that is allowed
 
@@ -43,7 +42,7 @@ max_value = 50.0 # Maximal allowed value
 max_increase_per_second = 8.0/3600.0   # Maximal allowed increase per second (for window variation check)
 max_decrease_per_second = 10.0/3600.0   # Maximal allowed decrease per second (for window variation check)
 time_window_to_check = '1h'   # Use this format as example: "1h20min50s"
-min_window_members = 5 # Minimal number of records in window to perform check
+min_window_members = 3 # Minimal number of records in window to perform check
 
 max_increase_per_second_step = 8.0/3600.0   # Maximal allowed increase per second (for step check)
 max_decrease_per_second_step = -10.0/3600.0   # Maximal allowed increase per second (for step check)

--- a/vlinder_toolkit/dataset.py
+++ b/vlinder_toolkit/dataset.py
@@ -584,6 +584,7 @@ class Dataset:
         outliersdf = add_final_label_to_outliersdf(
                         outliersdf=self.outliersdf,
                         data_res_series=self.metadf['dataset_resolution'])
+        
         #remove duplicate indixes (needed for update)
         outliersdf = outliersdf[~outliersdf.index.duplicated(keep='first')]
         

--- a/vlinder_toolkit/qc_checks.py
+++ b/vlinder_toolkit/qc_checks.py
@@ -140,7 +140,7 @@ def invalid_input_check(df):
                                                      flagcolumnname= checks_info[checkname]['label_columnname'],
                                                      flag=checks_info[checkname]['outlier_flag'])
         outl_df = pd.concat([outl_df, specific_outl_df])
-        
+
     return df, outl_df
 
   
@@ -188,7 +188,6 @@ def duplicate_timestamp_check(df):
     
     #add label
     outliers[checks_info[checkname]['label_columnname']] = checks_info[checkname]['outlier_flag']
-   
    
     return df, outliers
 
@@ -289,42 +288,58 @@ def persistance_check(station_frequencies, obsdf, obstype):
         logger.warning(f'No {checkname} settings found for obstype={obstype}. Check is skipped!')
         return obsdf, init_multiindexdf()
     
-    # drop outliers from the series (these are Nan's)
-    input_series = obsdf[obstype].dropna()
+    invalid_windows_check_df = pd.to_timedelta(specific_settings['time_window_to_check'])/station_frequencies < specific_settings['min_num_obs']
+    invalid_stations = list(invalid_windows_check_df[invalid_windows_check_df == True].index)
+    if invalid_stations:
+        print(f'The windows are too small for stations  {invalid_stations} to perform persistance check')
+        logger.info(f'The windows are too small for stations  {invalid_stations} to perform persistance check')
     
+    subset_not_used = obsdf[obsdf.index.get_level_values('name').isin(invalid_stations)]
+    subset_used = obsdf[~obsdf.index.get_level_values('name').isin(invalid_stations)]
     
-    #apply persistance
-    def is_unique(window):   #comp order of N (while using the 'unique' function is Nlog(N))
-        a = window.values
-        a = a[~np.isnan(a)]
-        return (a[0] == a).all()
-    
-    #TODO: Tis is very expensive if no coarsening is applied !!!! Can we speed this up? 
-    window_output = input_series.reset_index(level=0).groupby('name').rolling(window= specific_settings['time_window_to_check'],
-                                                                            closed='both',
-                                                                            center=True,
-                                                                            min_periods=specific_settings['min_num_obs']).apply(is_unique)
-    
-    
-    list_of_outliers = []
-    outl_obs = window_output.loc[window_output[obstype] == True].index
-    for outlier in outl_obs:
-        outliers_list = get_outliers_in_daterange(input_series, outlier[1], outlier[0], specific_settings['time_window_to_check'], station_frequencies)
-      
-        list_of_outliers.extend(outliers_list)
+    if not subset_used.empty:
+        # drop outliers from the series (these are Nan's)
+        input_series = subset_used[obstype].dropna()
         
-    list_of_outliers = list(set(list_of_outliers))
+        
+        #apply persistance
+        def is_unique(window):   #comp order of N (while using the 'unique' function is Nlog(N))
+            a = window.values
+            a = a[~np.isnan(a)]
+            return (a[0] == a).all()
+        
+        #TODO: Tis is very expensive if no coarsening is applied !!!! Can we speed this up? 
+        window_output = input_series.reset_index(level=0).groupby('name').rolling(window= specific_settings['time_window_to_check'],
+                                                                                closed='both',
+                                                                                center=True,
+                                                                                min_periods=specific_settings['min_num_obs']).apply(is_unique)
+        
+        
+        list_of_outliers = []
+        outl_obs = window_output.loc[window_output[obstype] == True].index
+        for outlier in outl_obs:
+            outliers_list = get_outliers_in_daterange(input_series, outlier[1], outlier[0], specific_settings['time_window_to_check'], station_frequencies)
+          
+            list_of_outliers.extend(outliers_list)
+            
+        list_of_outliers = list(set(list_of_outliers))
+        
     
-
-    #make new obsdf and outlierdf
-    obsdf, outlier_df = make_outlier_df_for_check(station_dt_list=list_of_outliers,
-                                           obsdf=obsdf,
-                                           obstype=obstype,
-                                           flagcolumnname=checks_info[checkname]['label_columnname'],
-                                           flag=checks_info[checkname]['outlier_flag'])
+        #make new obsdf and outlierdf
+        subset_used, outlier_df = make_outlier_df_for_check(station_dt_list=list_of_outliers,
+                                               obsdf=subset_used,
+                                               obstype=obstype,
+                                               flagcolumnname=checks_info[checkname]['label_columnname'],
+                                               flag=checks_info[checkname]['outlier_flag'])
   
-   
-    return obsdf, outlier_df
+        obsdf = pd.concat([subset_used, subset_not_used])
+        
+        return obsdf, outlier_df
+    
+    else:
+        obsdf = pd.concat([subset_used, subset_not_used])
+        
+        return obsdf, init_multiindexdf()
       
 
 
@@ -512,53 +527,71 @@ def window_variation_check(station_frequencies, obsdf, obstype):
         print(f'No {checkname} settings found for obstype={obstype}. Check is skipped!')
         logger.warning(f'No {checkname} settings found for obstype={obstype}. Check is skipped!')
         return obsdf, init_multiindexdf()
-     
-    # drop outliers from the series (these are Nan's)
-    input_series = obsdf[obstype].dropna()
-         
     
-    # Calculate window thresholds (by linear extarpolation)
-    windowsize_seconds = pd.Timedelta(specific_settings['time_window_to_check']).total_seconds()
-    max_window_increase = specific_settings['max_increase_per_second'] * windowsize_seconds
-    max_window_decrease = specific_settings['max_decrease_per_second'] * windowsize_seconds
+    invalid_windows_check_df = pd.to_timedelta(specific_settings['time_window_to_check'])/station_frequencies < specific_settings['min_window_members']
+    invalid_stations = list(invalid_windows_check_df[invalid_windows_check_df == True].index)
+    if invalid_stations:
+        print(f'The windows are too small for stations  {invalid_stations} to perform window variation check')
+        logger.info(f'The windows are too small for stations  {invalid_stations} to perform window variation check')
+    
+    subset_not_used = obsdf[obsdf.index.get_level_values('name').isin(invalid_stations)]
+    subset_used = obsdf[~obsdf.index.get_level_values('name').isin(invalid_stations)]
+    
+    if not subset_used.empty:
         
-    
-    #apply steptest
-    def variation_test(window):
-         if ((max(window) - min(window) > max_window_increase) & 
-             (window.idxmax() > window.idxmin())):
-             return 1
-    
-         if ((max(window) - min(window) > max_window_decrease) & 
-             (window.idxmax() < window.idxmin())):
-             return 1
-         else:
-             return 0
-            
-    window_output = input_series.reset_index(level=0).groupby('name').rolling(window=specific_settings['time_window_to_check'],
-                                                                             closed='both',
-                                                                             center=True,
-                                                                             min_periods=specific_settings['min_window_members']).apply(variation_test)
-    
-    list_of_outliers = []
-    outl_obs = window_output.loc[window_output[obstype] == 1].index
-    
-    for outlier in outl_obs:
-        outliers_list = get_outliers_in_daterange(input_series, outlier[1], outlier[0], specific_settings['time_window_to_check'], station_frequencies)
-          
-        list_of_outliers.extend(outliers_list)
-            
-    list_of_outliers = list(set(list_of_outliers))
+        # drop outliers from the series (these are Nan's)
+        input_series = subset_used[obstype].dropna()
+             
         
-    #make new obsdf and outlierdf
-    obsdf, outlier_df = make_outlier_df_for_check(station_dt_list=list_of_outliers,
-                                            obsdf=obsdf,
-                                            obstype=obstype,
-                                            flagcolumnname=checks_info[checkname]['label_columnname'],
-                                            flag=checks_info[checkname]['outlier_flag'])
-
+        # Calculate window thresholds (by linear extarpolation)
+        windowsize_seconds = pd.Timedelta(specific_settings['time_window_to_check']).total_seconds()
+        max_window_increase = specific_settings['max_increase_per_second'] * windowsize_seconds
+        max_window_decrease = specific_settings['max_decrease_per_second'] * windowsize_seconds
+            
+        
+        #apply steptest
+        def variation_test(window):
+            if ((max(window) - min(window) > max_window_increase) & 
+                (window.idxmax() > window.idxmin())):
+                return 1
+        
+            if ((max(window) - min(window) > max_window_decrease) & 
+                (window.idxmax() < window.idxmin())):
+                return 1
+            else:
+                return 0
+                
+        window_output = input_series.reset_index(level=0).groupby('name').rolling(window=specific_settings['time_window_to_check'],
+                                                                                  closed='both',
+                                                                                  center=True,
+                                                                                  min_periods=specific_settings['min_window_members']).apply(variation_test)
+        
+        list_of_outliers = []
+        outl_obs = window_output.loc[window_output[obstype] == 1].index
+        
+        for outlier in outl_obs:
+            outliers_list = get_outliers_in_daterange(input_series, outlier[1], outlier[0], specific_settings['time_window_to_check'], station_frequencies)
+              
+            list_of_outliers.extend(outliers_list)
+                
+        list_of_outliers = list(set(list_of_outliers))
+            
+        #make new obsdf and outlierdf
+        subset_used, outlier_df = make_outlier_df_for_check(station_dt_list=list_of_outliers,
+                                                      obsdf=subset_used,
+                                                      obstype=obstype,
+                                                      flagcolumnname=checks_info[checkname]['label_columnname'],
+                                                      flag=checks_info[checkname]['outlier_flag'])
     
-    return obsdf, outlier_df
+        obsdf = pd.concat([subset_used, subset_not_used])
+        
+        return obsdf, outlier_df
+    
+    else:
+        obsdf = pd.concat([subset_used, subset_not_used])
+        
+        return obsdf, init_multiindexdf()
+        
 
 def get_outliers_in_daterange(input_data, date, name, time_window, station_freq):
     end_date = date + (pd.Timedelta(time_window)/2).floor(station_freq[name])

--- a/vlinder_toolkit/qc_checks.py
+++ b/vlinder_toolkit/qc_checks.py
@@ -290,7 +290,7 @@ def persistance_check(station_frequencies, obsdf, obstype):
     
     invalid_windows_check_df = pd.to_timedelta(specific_settings['time_window_to_check'])/station_frequencies < specific_settings['min_num_obs']
     invalid_stations = list(invalid_windows_check_df[invalid_windows_check_df == True].index)
-    if invalid_stations:
+    if bool(invalid_stations):
         print(f'The windows are too small for stations  {invalid_stations} to perform persistance check')
         logger.info(f'The windows are too small for stations  {invalid_stations} to perform persistance check')
     
@@ -530,7 +530,7 @@ def window_variation_check(station_frequencies, obsdf, obstype):
     
     invalid_windows_check_df = pd.to_timedelta(specific_settings['time_window_to_check'])/station_frequencies < specific_settings['min_window_members']
     invalid_stations = list(invalid_windows_check_df[invalid_windows_check_df == True].index)
-    if invalid_stations:
+    if bool(invalid_stations):
         print(f'The windows are too small for stations  {invalid_stations} to perform window variation check')
         logger.info(f'The windows are too small for stations  {invalid_stations} to perform window variation check')
     


### PR DESCRIPTION
If window variation check can not be performed for specific stations because there are not enough observations per window, this should be printed to the user.